### PR TITLE
Fix Azure functions version - lower case v4 - AB#431979

### DIFF
--- a/EPR.EventDispatcher/EPR.EventDispatcher.Functions/EPR.EventDispatcher.Functions.csproj
+++ b/EPR.EventDispatcher/EPR.EventDispatcher.Functions/EPR.EventDispatcher.Functions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <AzureFunctionsVersion>V4</AzureFunctionsVersion>
+        <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />


### PR DESCRIPTION
The version in the function app .csproj file was set to

`<AzureFunctionsVersion>V4</AzureFunctionsVersion>`

When developers run this on their own machines, the functions wouldn't start. The version should have a lowercase v:

`<AzureFunctionsVersion>v4</AzureFunctionsVersion>`